### PR TITLE
return promise from piloted.config if no callback provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ backend that your service depends on.
 
 ### API
 
-#### config(config, callback)
+#### config(config [, callback])
 
 Pass the `containerpilot.json` file as a parsed object. The properties that are
 used by _piloted_ are `consul` and `backends`. These will be used to connect to
@@ -43,6 +43,8 @@ cares about.
   - `CONSUL_PORT`
 * `callback` - function to be executed after the initial cache of service data has
 been loaded. The function signature is `(err)`
+
+If a `callback` is omitted, a `Promise` will be returned.
 
 
 #### (name)

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@
 const Consulite = require('consulite');
 const Hoek = require('hoek');
 const Items = require('items');
+const OrPromise = require('or-promise');
 
 
 // Declare internals
@@ -24,6 +25,7 @@ module.exports = function (service) {
 module.exports.config = function (config, callback) {
   Hoek.assert(config && typeof config === 'object', 'Config must exist and be an object');
   Hoek.assert(config.backends && config.backends.length, 'Config must contain backends');
+  callback = callback || OrPromise();
 
   Consulite.config({ consul: config.consul });
 
@@ -34,6 +36,8 @@ module.exports.config = function (config, callback) {
   Items.parallel(internals.services, (service, next) => {
     Consulite.getService(service, next);
   }, callback);
+
+  return callback.promise;
 };
 
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "consulite": "1.x.x",
     "hoek": "4.x.x",
     "items": "2.x.x",
-    "or-promise": "~1.0.0"
+    "or-promise": "1.x.x"
   },
   "devDependencies": {
     "belly-button": "3.x.x",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "consulite": "1.x.x",
     "hoek": "4.x.x",
-    "items": "2.x.x"
+    "items": "2.x.x",
+    "or-promise": "~1.0.0"
   },
   "devDependencies": {
     "belly-button": "3.x.x",

--- a/test/index.js
+++ b/test/index.js
@@ -45,7 +45,12 @@ describe('config()', () => {
 
       Piloted.config(config, () => {
         expect(Piloted('nginx').port).to.equal('1234');
-        done();
+
+        // will resolve a returned promise in absence of callback
+        Piloted.config(config).then(() => {
+          expect(Piloted('nginx').port).to.equal('1234');
+          done();
+        });
       });
     });
   });
@@ -90,7 +95,12 @@ describe('config()', () => {
 
       Piloted.config(config, (err) => {
         expect(err).to.exist();
-        done();
+
+        // will reject a returned promise in absence of callback
+        Piloted.config(config).catch((err) => {
+          expect(err).to.exist();
+          done();
+        });
       });
     });
   });


### PR DESCRIPTION
This PR uses the very tiny (no dependency) [or-promise](https://github.com/jasonpincin/or-promise) module to add support for returning a promise from `piloted.config` only if no callback is provided. This change would have no impact when a callback is provided.

This enabled support for async/await style programming. Example:

```javascript
const co = require('co')
const piloted = require('piloted')
const request = require('request-promise-native')

co(function *main () {
    try {
        yield piloted.config(require('./containerpilot.json'))
        const service = piloted('customers')
        const payload = yield request(`http://${service.address}:${service.port}/?q=steven`)
        // handle payload
    }
    catch (err) {
        // handle err
    }
})
```