### PR TITLE
Add templating functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,10 @@ Example:
 ```js
 const service = Piloted('my-service');
 ```
+
+### Templating
+
+Piloted will template your configuration file, similar to the way that
+[ContainerPilot](https://www.joyent.com/containerpilot/docs/configuration)
+does. If you have an environment variable such as `FOO=BAR` then you can use
+`{{.FOO}}` in your configuration file and it will be substituted with `BAR`.

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,6 +26,7 @@ module.exports.config = function (config, callback) {
   Hoek.assert(config && typeof config === 'object', 'Config must exist and be an object');
   Hoek.assert(config.backends && config.backends.length, 'Config must contain backends');
   callback = callback || OrPromise();
+  config = internals.template(config);
 
   Consulite.config({ consul: config.consul });
 
@@ -40,6 +41,13 @@ module.exports.config = function (config, callback) {
   return callback.promise;
 };
 
+internals.template = function (obj) {
+  const str = JSON.stringify(obj);
+  const templated = str.replace(/\{\{\s*\.(\w+)\s*\}\}/g, (match, capture) => {
+    return process.env[capture] || match;
+  });
+  return JSON.parse(templated);
+};
 
 process.on('SIGHUP', () => {
   // Don't refresh if we are currently refreshing the services

--- a/test/index.js
+++ b/test/index.js
@@ -133,7 +133,7 @@ describe('config()', () => {
     });
   });
 
-  it('replaces leaves templates in the config without environment variables', (done) => {
+  it('leaves templates in the config without environment variables', (done) => {
     const server = Http.createServer((req, res) => {
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify([


### PR DESCRIPTION
This pull request adds templating functionality to Piloted similar to what ContainerPilot does (see the "Template Configuration" section of [the docs](https://www.joyent.com/containerpilot/docs/configuration)).

- Sections in brackets with a leading period are replaced with environment variables with the same name.
- Templated sections that do not have a corresponding environment variable set are left untouched.

So assuming that the environment variable `FOO` is set to `bar`:

- `{{ .FOO }}.com/stuffing` is transformed into `bar.com/stuffing`
- `{{ .BAZ }}.com/cranberries` is not transformed, because there is no environment variable `BAZ` defined. It remains as `{{ .BAZ }}.com/cranberries`.