### PR TITLE
Add refresh event to Piloted so applications can adjust

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,26 @@ Piloted will template your configuration file, similar to the way that
 [ContainerPilot](https://www.joyent.com/containerpilot/docs/configuration)
 does. If you have an environment variable such as `FOO=BAR` then you can use
 `{{.FOO}}` in your configuration file and it will be substituted with `BAR`.
+
+### Events
+`Piloted` implements the [events](https://nodejs.org/docs/latest/api/events.html) interface. Specifically, if you need to know when the data has been updated, you can listen for the `refresh` event:
+
+```js
+Piloted.on('refresh',function () {
+  // update anything that needs to be done
+});
+```
+
+A common use case is long-lived connections, e.g. database connections:
+
+```js
+Piloted(config, (err) => {
+  const service = Piloted('db');
+  var db = createDbConnectionWithFavouriteDriver(service.address, services.port);
+  Piloted.on('refresh',function () {
+    // update anything that needs to be done
+    db.release();
+    db.connect(service.address, service.port);
+  });
+});
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,8 @@ const Consulite = require('consulite');
 const Hoek = require('hoek');
 const Items = require('items');
 const OrPromise = require('or-promise');
+const EventEmitter = require('events');
+const myEmitter = new EventEmitter();
 
 
 // Declare internals
@@ -63,5 +65,22 @@ process.on('SIGHUP', () => {
     Consulite.refreshService(service, next);
   }, () => {
     internals.refreshing = false;
+    myEmitter.emit('refresh');
   });
 });
+
+module.exports.on = function () {
+  myEmitter.on.apply(myEmitter, arguments);
+};
+module.exports.once = function () {
+  myEmitter.once.apply(myEmitter, arguments);
+};
+module.exports.removeListener = function () {
+  myEmitter.once.removeListener(myEmitter, arguments);
+};
+module.exports.removeAllListener = function () {
+  myEmitter.once.removeAllListener(myEmitter, arguments);
+};
+module.exports.addListener = function () {
+  myEmitter.on.addListener(myEmitter, arguments);
+};

--- a/test/index.js
+++ b/test/index.js
@@ -265,4 +265,16 @@ describe('SIGHUP', () => {
       }
     }, 200);
   });
+
+  it('passes \'refresh\' event', (done) => {
+    var count = 0;
+    Piloted.on('refresh', function () {
+      count++;
+    });
+    process.emit('SIGHUP');
+    setTimeout(() => {
+      expect(count).to.equal(1);
+      done();
+    }, 200);
+  });
 });


### PR DESCRIPTION
This fulfills https://github.com/joyent/node-piloted/issues/6

Enables applications to get events that tell it when the list of services has been updated (via `SIGHUP` captured by `Piloted`), so it can adjust, e.g. terminating/recreating long-lived connections.